### PR TITLE
docs: add deep review artifacts for issue triage

### DIFF
--- a/review/2026-03-01-deep-review/00-swarm-overview.md
+++ b/review/2026-03-01-deep-review/00-swarm-overview.md
@@ -1,0 +1,19 @@
+# FPF Deep Review (Swarm) — 2026-03-01
+
+Scope: full `FPF-Spec.md` review with 4 parallel reviewers (A/B, C/D/E, F/G, global integrity).
+
+Key meta-results:
+- Upstream sync: local branch already aligned with `upstream/main`.
+- File reviewed: `FPF-Spec.md` (51305 lines).
+- Main issue families identified:
+  - roadmap/missing section IDs referenced ahead of implementation,
+  - unresolved cross-references,
+  - parser-breaking markdown table structure,
+  - section boundary marker corruption,
+  - subsection ID collisions,
+  - ID style drift,
+  - status enum drift,
+  - localized Part F table integrity issues,
+  - editorial defects.
+
+Issue/PR plan is split into separate tracks below in this folder.

--- a/review/2026-03-01-deep-review/01-future-work-roadmap-missing-sections.md
+++ b/review/2026-03-01-deep-review/01-future-work-roadmap-missing-sections.md
@@ -1,0 +1,20 @@
+# Future Work / Roadmap Issue
+
+## Topic
+Planned-but-not-yet-written section IDs are referenced in the spec for forward-compatible reasoning support.
+
+## Intent
+Keep references, but mark them explicitly as roadmap placeholders to avoid false conformance expectations.
+
+## Missing section IDs (sample)
+- `A.22`..`A.45` family references (including `A.27`) used by A.20/A.21/E.18 and G.* surfaces.
+- `C.1`, `C.4`..`C.7`, `C.9`..`C.12`, `C.14`, `C.15` listed/used but not fully implemented as `##` sections.
+- `D.1`..`D.4.2`, `D.5.1`, `D.5.2` listed but not implemented as full sections.
+
+## Evidence
+- `FPF-Spec.md` lines: 100, 101, 155-168, 186-200, 20531, 20917, 30107, 30759, 31202, 31923, 32239, 32396, 37476, 37562, 37744, 48869, 49714, 50862.
+
+## Proposed handling
+- Add explicit roadmap marker policy in spec (e.g., `PlannedPlaceholder: yes`).
+- Keep IDs for LLM context, but remove normative dependency semantics unless section body exists.
+- Optionally add minimal `##` placeholder sections with status `Planned` and explicit non-normative disclaimer.

--- a/review/2026-03-01-deep-review/02-future-work-unresolved-references.md
+++ b/review/2026-03-01-deep-review/02-future-work-unresolved-references.md
@@ -1,0 +1,16 @@
+# Future Work / Roadmap Issue — Unresolved References
+
+## Topic
+Reference tokens exist, but target sections are missing.
+
+## Example
+- `A.27` is unresolved but used by G.* normative surfaces.
+
+## Evidence
+- `FPF-Spec.md` lines: 48869, 49714, 50862.
+
+## Proposed handling
+- Either add `## A.27` section, or replace `A.27` references with concrete existing owner IDs.
+
+## Additional unresolved references to classify
+- `A.22`, `A.23`, `A.24`, `A.25`, `A.26`, `A.28`, `A.29`, `A.31`, `A.32`, `A.33`, `A.34`, `A.37`, `A.40`, `A.41`, `A.42`, `A.45`, `E.23`.

--- a/review/2026-03-01-deep-review/03-issue-pr-toc-table-schema.md
+++ b/review/2026-03-01-deep-review/03-issue-pr-toc-table-schema.md
@@ -1,0 +1,13 @@
+# Issue + PR: ToC/Table Schema Parser Breakage
+
+## Problem
+ToC/table markdown structure is parser-breaking.
+
+## Evidence
+- Missing row terminator: `FPF-Spec.md` line 61.
+- Unescaped `|` in table cells: lines 94-99, 229, 279.
+
+## Fix plan
+- Close malformed row.
+- Escape literal pipes in table cells.
+- Keep content unchanged semantically.

--- a/review/2026-03-01-deep-review/04-issue-pr-section-boundary-markers.md
+++ b/review/2026-03-01-deep-review/04-issue-pr-section-boundary-markers.md
@@ -1,0 +1,12 @@
+# Issue + PR: Section Boundary Marker Corruption
+
+## Problem
+At least two section end markers point to wrong IDs.
+
+## Evidence
+- `C.25` closes as `C.23:End` at line 32109.
+- `E.13` closes as `E.10:End` at line 35239.
+
+## Fix plan
+- Correct markers to `C.25:End` and `E.13:End`.
+- Add a lightweight heading↔end consistency lint script.

--- a/review/2026-03-01-deep-review/05-issue-only-b4-and-section8-systemic.md
+++ b/review/2026-03-01-deep-review/05-issue-only-b4-and-section8-systemic.md
@@ -1,0 +1,18 @@
+# Issue Only (No Fix Yet): B.4 Subsections + Section-8 Systemic Template Drift
+
+## Problem A
+`B.4.1/B.4.2/B.4.3` are marked Stable in ToC but not implemented as canonical `##` sections.
+
+### Evidence
+- ToC: lines 127-129.
+- Body has `B.4-1/2/3` bullets only: lines 24493, 24501, 24509.
+
+## Problem B
+Canonical section-8 template requirement is violated systemically.
+
+### Evidence
+- Requirement: line 33305.
+- Violations sample: lines 5422, 21060, 24007, 24798.
+
+## Requested handling
+Track as separate issue for design decision first; no direct patch in this wave.

--- a/review/2026-03-01-deep-review/06-issue-pr-duplicate-subsection-ids-part-f.md
+++ b/review/2026-03-01-deep-review/06-issue-pr-duplicate-subsection-ids-part-f.md
@@ -1,0 +1,12 @@
+# Issue + PR: Duplicate Subsection IDs in Part F
+
+## Problem
+Duplicate subsection IDs create anchor collisions.
+
+## Evidence
+- `F.2:6.2` appears at lines 39192 and 39204.
+- `F.18:21` appears at lines 45047 and 45077.
+
+## Fix plan
+- Renumber the second occurrence in each pair.
+- Update any direct references if present.

--- a/review/2026-03-01-deep-review/07-issue-pr-id-style-drift-machine-joins.md
+++ b/review/2026-03-01-deep-review/07-issue-pr-id-style-drift-machine-joins.md
@@ -1,0 +1,13 @@
+# Issue + PR: ID Style Drift Breaking Machine Joins
+
+## Problem
+Equivalent references use incompatible ID forms.
+
+## Evidence
+- `B.4.1` vs `B.4-1`: lines 127 and 24493.
+- `G.5.Select` vs `G.5-3 Select`: lines 49623 and 47866.
+- `G.6:H8` vs canonical `G.6:7.5.8`: lines 41158 and 48394.
+
+## Fix plan
+- Normalize tokens to canonical form in current spec.
+- Preserve readability labels separately from machine IDs.

--- a/review/2026-03-01-deep-review/08-issue-pr-status-enum-drift.md
+++ b/review/2026-03-01-deep-review/08-issue-pr-status-enum-drift.md
@@ -1,0 +1,12 @@
+# Issue + PR: Status Enum Drift and Contradictions
+
+## Problem
+Status values and status assignments are inconsistent.
+
+## Evidence
+- `A.2.7` status mismatch: line 46 (`New`) vs line 4599 (`Stable`).
+- enum case drift: line 228 (`stable`), line 315 (`stub`).
+
+## Fix plan
+- Normalize status vocabulary (`Stable`, `Draft`, `Stub`, etc.).
+- Align ToC and section status for `A.2.7`.

--- a/review/2026-03-01-deep-review/09-issue-pr-part-f-table-integrity.md
+++ b/review/2026-03-01-deep-review/09-issue-pr-part-f-table-integrity.md
@@ -1,0 +1,12 @@
+# Issue + PR: Additional Part F Table Integrity Fixes
+
+## Problem
+Several Part F tables are malformed for strict parsing.
+
+## Evidence
+- Malformed rows: lines 40309, 40314.
+- Unescaped pipes in cells: lines 45197, 45482, 45872.
+
+## Fix plan
+- Add missing trailing delimiters.
+- Escape literal pipes in table content.

--- a/review/2026-03-01-deep-review/10-issue-pr-editorial-drift-typos.md
+++ b/review/2026-03-01-deep-review/10-issue-pr-editorial-drift-typos.md
@@ -1,0 +1,13 @@
+# Issue + PR: Editorial Drift / Typos / Minor Syntax Defects
+
+## Problem
+Editorial defects and minor syntax drift reduce readability and trust.
+
+## Evidence
+- `Extention` typo: lines 138, 33117.
+- Stray heading `**`: line 8865.
+- Title mismatch: line 112 vs line 22177.
+
+## Fix plan
+- Correct typos/syntax.
+- Harmonize title wording for same ID across ToC and section heading.


### PR DESCRIPTION
Adds separate markdown dossiers for deep review findings and issue/PR planning.

Related: #11